### PR TITLE
GitHub Linguist support for adblock rules

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: medavox's uBlock Origin Rules list
 ! Description: Lovingly handcrafted ad- and annoyance-blocking rules by your favourite nobody developer
 ! Expires: 10 days

--- a/wp-restyle2.txt
+++ b/wp-restyle2.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 !simpler wikipedia restyle: flow the article around the sidebar
 !(achieved by restyling an empty <a> element within the content div to provide the gap
 en.wikipedia.org##div#content.mw-body:style(margin-left: 0.5em !important)

--- a/ytbs.txt
+++ b/ytbs.txt
@@ -1,3 +1,4 @@
+[uBlock Origin]
 ! Title: YouTube Bullshit filter
 ! Description: Hides annoying bullshit content. The sort that talks about taking things back, or making things great again.
 ! Expires: 10 days

--- a/ytdf.txt
+++ b/ytdf.txt
@@ -1,3 +1,4 @@
+[Adblock Plus 2.0; uBlock Origin]
 ! Title: YouTube Distraction-Free emulation
 ! Description: Hides distracting or annoying YouTube UI elements.
 ! Expires: 10 days


### PR DESCRIPTION
GitHub has been supporting adblock syntax highlighting since September 5th. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401